### PR TITLE
Update to download link on navigation bar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,7 +9,7 @@ links:
   - title: Setup Guide
     collection: setup-guide
   - title: Download
-    url: /download/
+    url: /home/
     sublinks:
       - title: iOS app
         url: https://apps.apple.com/sg/app/scamshield/id1497144087

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,7 +9,7 @@ links:
   - title: Setup Guide
     collection: setup-guide
   - title: Download
-    url: /permalink/
+    url: /download/
     sublinks:
       - title: iOS app
         url: https://apps.apple.com/sg/app/scamshield/id1497144087

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,7 +9,7 @@ links:
   - title: Setup Guide
     collection: setup-guide
   - title: Download
-    url: /download/
+    url: /
     sublinks:
       - title: iOS app
         url: https://apps.apple.com/sg/app/scamshield/id1497144087

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,7 +9,7 @@ links:
   - title: Setup Guide
     collection: setup-guide
   - title: Download
-    url: /home/
+    url: /download/
     sublinks:
       - title: iOS app
         url: https://apps.apple.com/sg/app/scamshield/id1497144087


### PR DESCRIPTION
Download tab on the navigation bar now goes to a 404 page - I changed this to "/" so it points back to the main page. Ideal user journey is for users to click onto the dropdown links to go directly to the Android/Apple download page.