### PR TITLE
Change Report a Scam Form to a hyperlink 

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,7 +5,7 @@ links:
   - title: FAQ
     url: /faq/
   - title: Report a Scam
-    url: /report/
+    url: https://form.gov.sg/63982e109841390011a59121
   - title: Setup Guide
     collection: setup-guide
   - title: Download

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ sections:
           url: /faq/
         - title: Report a scam
           description: Help us make ScamShield better
-          url: /report/
+          url: https://form.gov.sg/63982e109841390011a59121
         - title: Get the latest scam information
           description: Visit ScamAlert.sg
           url: https://www.scamalert.sg

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:108%;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:100%;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:110%;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:105%;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:900px;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:1000px;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:120%;height:800px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:700px;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:100%;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:110%;height:1500px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:150%;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:120%;height:800px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:800px;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:900px;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:1000px;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:110%;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:120%;height:1500px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:108%;height:1500px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:100%;height:500px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:150%;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:105%;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:108%;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:110%;height:1500px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:120%;height:1500px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:108%;height:1500px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:108%;height:2500px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -5,6 +5,6 @@ permalink: /report/
 <div style="font-family:Sans-Serif;font-size:15px;color:#000;opacity:0.9;padding-top:5px;padding-bottom:8px">If the form below doesn't load, you can also fill it in <a href="https://form.gov.sg/63982e109841390011a59121">here</a>.</div>
 
 <!-- Change the width and height values to suit you best -->
-<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:700px;height:1000px"></iframe>
+<iframe id="iframe" src="https://form.gov.sg/63982e109841390011a59121" style="width:800px;height:1000px"></iframe>
 
 <div style="font-family:Sans-Serif;font-size:12px;color:#999;opacity:0.5;padding-top:5px">Powered by <a href="https://form.gov.sg" style="color: #999">FormSG</a></div>


### PR DESCRIPTION
It was commented that the FormSG in an iFrame is not a great UX for MOPs. To mitigate this, the Report a Scam tab has been shifted to a hyperlink that opens the form in a separate tab. I have also increased the size of the iFrame as large as it goes. 